### PR TITLE
feat: deploy development images to docker hub

### DIFF
--- a/.github/workflows/pull-images.yml
+++ b/.github/workflows/pull-images.yml
@@ -1,0 +1,32 @@
+# Pull the Docker images from Docker Hub on schedule
+name: Pull Docker Images
+
+on:
+  schedule:
+    # Runs "At 00:00 on day-of-month 1 in every 2nd month."
+    # - cron: '0 0 1 */2 *'
+    - cron: '0 */2 * * *' # Runs every 2 hours
+
+jobs:
+  pull-images:
+    name: Pull Development Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+
+      - name: Fetch and check out latest tag
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Checking out latest tag: $LATEST_TAG"
+          git checkout $LATEST_TAG
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Pull Development Image
+        run: docker compose -f docker-compose.dev.yml pull
+
+      - name: Pull Tagged Image
+        run: |
+          sed -i -e "s/latest/${{ env.LATEST_TAG }}/g" docker-compose.dev.yml
+          docker compose -f docker-compose.dev.yml pull

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Deploy to Production Environment
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker-build-push:
+    name: Push Image to Docker Hub
+    if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Build Image
+        run: docker compose -f docker-compose.dev.yml build
+
+      - name: Push Image to Docker Hub
+        run: docker compose -f docker-compose.dev.yml push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,29 @@ on:
     types: [published]
 
 jobs:
+  docker-build-push-tag:
+    name: Push Tagged Image
+    if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Set release version number
+        run: sed -i -e "s/latest/${{ github.event.release.tag_name }}/g" docker-compose.dev.yml
+      - name: Build Image
+        run: docker compose -f docker-compose.dev.yml build
+      - name: Push Image to Docker Hub
+        run: docker compose -f docker-compose.dev.yml push
+
   docker-build-push:
-    name: Push Image to Docker Hub
+    name: Push Development Image
     if: github.event.release.target_commitish == 'master' && vars.DOCKERHUB_USERNAME != ''
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 - [Usage](#usage)
 - [Available Scripts](#available-scripts)
 - [Usage with Docker](#usage-with-docker)
+   - [Using the Pre-Built Docker Image](#using-the-pre-built-docker-image)
    - [Local-Built Development Image](#local-built-development-image)
 - [Building Docker Images](#building-docker-images)
 - [Other Notes](#other-notes)
    - [Debugging Webpack Apps in VSCode](#debugging-webpack-apps-in-vscode)
+- [Deployment with GitHub Actions](#deployment-with-gitHub-actions)
 - [References](#references)
 
 
@@ -83,6 +85,43 @@ Builds the static website output using webpack into the **"/dist"** directory.
 
 ## Usage with Docker
 
+### Using the Pre-Built Docker Image
+
+This project deploys the latest **development** Docker image to Docker Hub on the creation of new Release/Tags. It is available at:
+
+https://hub.docker.com/r/weaponsforge/livereload-webpack
+
+1. Pull the pre-built development Docker images using any of the two (2) options:
+   - Open a terminal and run:<br>
+	    `docker pull weaponsforge/livereload-webpack:latest`
+   - Navigate to the gsites-components root project directory, then run:<br>
+	    `docker compose -f docker-compose.dev.yml pull`
+
+2. Run the development image.<br>
+   - Using only Docker (1st option):
+
+      > **INFO:** This option requires having the webpack web app files inside a `"/src"` directory.
+
+      ```
+      # On Linux OS
+      docker run -it --rm -p 8080:8080 -v $(pwd)/src:/opt/app/src weaponsforge/livereload-webpack:latest
+
+      # On Windows OS
+      docker run -it --rm -p 8080:8080 -v %cd%\src:/opt/app/src -e WATCHPACK_POLLING=true weaponsforge/livereload-webpack:latest
+      ```
+
+   - Using Docker compose (2nd option):<br>
+      - `docker compose -f docker-compose.dev.yml up`
+      - > **INFO:** Uncomment the following lines in the `docker-compose.dev.yml` file when working in a Windows host.
+         ```
+         # Enable WATCHPACK_POLLING if working in Windows WSL2 to enable hot reload
+         environment:
+           - WATCHPACK_POLLING=true
+         ```
+
+
+3. Refer to the [Usage](#usage) section **steps # 2 - # 4** for local development.
+
 ### Local-Built Development Image
 
 1. Build the Docker image for local development.<br>
@@ -93,7 +132,7 @@ Builds the static website output using webpack into the **"/dist"** directory.
 2. Run the development image.<br>
 `docker compose -f docker-compose.dev.yml up`
 
-3. Refer to the [Usage](#usage) section **steps # 2 - # 4** for development.
+3. Refer to the [Usage](#usage) section **steps # 2 - # 4** for local development.
 
 4. Stop and exit the development container.<br>
 `docker compose -f docker-compose.dev.yml down`
@@ -111,6 +150,28 @@ The **development** Docker image contains Node runtime, Webpack dependencies, 
 The **production** Docker image contains the Webpack app's static build output running in an nginx container for minimal production website build. Build it with:
 
 `docker compose -f docker-compose.prod.yml build`
+
+## Deployment with GitHub Actions
+
+This repository deploys the local development Docker image to Docker Hub on creation of new Release/Tags. It is available at:
+
+https://hub.docker.com/r/weaponsforge/livereload-webpack
+
+Add the following GitHub Secrets and Variables to enable deployment to Docker Hub.
+
+#### GitHub Secrets
+
+| GitHub Secret | Description |
+| --- | --- |
+| DOCKERHUB_USERNAME | (Optional) Docker Hub username. Required to enable pushing the development image to Docker Hub. |
+| DOCKERHUB_TOKEN | (Optional) Deploy token for the Docker Hub account. Required to enable pushing the development image to Docker Hub. |
+
+#### GitHub Variables
+
+| GitHub Variable | Description |
+| --- | --- |
+| DOCKERHUB_USERNAME | (Optional) Docker Hub username. Required to enable pushing the development image to Docker Hub. |
+
 
 ## Other Notes
 


### PR DESCRIPTION
- Feat: deploy the latest development image to Docker Hub, [#28](https://github.com/weaponsforge/livereload-webpack/issues/28)
- Feat: deploy the latest tagged Release to Docker Hub
- Wip: test pulling the latest development and tagged images every 2 hours